### PR TITLE
Better error handling and surfacing as HTTP 4xx

### DIFF
--- a/src/electos/versadm/app/db/in_memory.py
+++ b/src/electos/versadm/app/db/in_memory.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from versadm.app.util.errors import ReferentialIntegrityError, DuplicateObjectError
+
 
 class EntityStore:
     def __init__(self):
@@ -25,7 +27,7 @@ class EntityStore:
         synonym_referents = {self.id_synonyms[ext_id] for ext_id in external_ids if ext_id in self.id_synonyms}
         if is_generated_id:
             if len(synonym_referents) > 1:
-                raise ValueError('External ids reference multiple known objects.')
+                raise ReferentialIntegrityError('External ids reference multiple known objects.')
             elif len(synonym_referents) == 1:
                 obj_id = list(synonym_referents)[0]
                 is_generated_id = False
@@ -35,10 +37,10 @@ class EntityStore:
         else:
             if synonym_referents.difference({obj_id}):
                 # the external ids refer to different internal ids than this object has
-                raise ValueError('External ids reference a different existing object.')
+                raise ReferentialIntegrityError('External ids reference a different existing object.')
 
         if not overwrite and obj_id in self.id_to_obj:
-            raise ValueError('Object already exists.')
+            raise DuplicateObjectError('Object already exists.')
 
         self.id_to_obj[obj_id] = value
         self.id_synonyms[obj_id] = obj_id

--- a/src/electos/versadm/app/main.py
+++ b/src/electos/versadm/app/main.py
@@ -1,11 +1,29 @@
 from fastapi import FastAPI
+from starlette.status import HTTP_400_BAD_REQUEST
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from versadm.app.db.in_memory import InMemoryDb
 from versadm.app import routers
+from versadm.app.util.errors import ReferentialIntegrityError, DuplicateObjectError
 
 
 def create_app(app_state=InMemoryDb()) -> FastAPI:
     app = FastAPI()
+
+    @app.exception_handler(ReferentialIntegrityError)
+    def handle_ref_error(_: Request, exc: ReferentialIntegrityError):
+        return JSONResponse(
+            status_code=HTTP_400_BAD_REQUEST,
+            content={'type': exc.error_code, 'msg': exc.args[0]}
+        )
+
+    @app.exception_handler(DuplicateObjectError)
+    def handle_duplicate_object_error(_: Request, exc: DuplicateObjectError):
+        return JSONResponse(
+            status_code=HTTP_400_BAD_REQUEST,
+            content={'type': exc.error_code, 'msg': exc.args[0]}
+        )
 
     app.include_router(routers.candidate.create_router(app_state))
     app.include_router(routers.contest.create_router(app_state))

--- a/src/electos/versadm/app/util/errors.py
+++ b/src/electos/versadm/app/util/errors.py
@@ -1,0 +1,27 @@
+import abc
+
+
+class CustomException(abc.ABC, Exception):
+    """
+    Abstract base class for custom exceptions for this application.
+    """
+    # noinspection PyPropertyDefinition
+    @classmethod
+    @property
+    @abc.abstractmethod
+    def error_code(cls):
+        raise NotImplementedError()
+
+
+class ReferentialIntegrityError(CustomException):
+    """
+    Raised when an attempt is made to store an object with invalid references to other objects.
+    """
+    error_code = 'ref-integrity'
+
+
+class DuplicateObjectError(CustomException):
+    """
+    Raised when an attempt is made to store an object with an id that is already in use by another object.
+    """
+    error_code = 'duplicate-obj'

--- a/src/electos/versadm/models/nist/util/__init__.py
+++ b/src/electos/versadm/models/nist/util/__init__.py
@@ -26,6 +26,9 @@ class ObjectId(BaseModel):
     def __hash__(self):
         return hash(self.__root__)
 
+    def __bool__(self):
+        return bool(self.__root__)
+
     def value(self):
         return self.__root__
 

--- a/test/versadm/models/app/errors_test.py
+++ b/test/versadm/models/app/errors_test.py
@@ -1,0 +1,213 @@
+from http.client import BAD_REQUEST
+import json
+import pytest
+
+from fastapi.testclient import TestClient
+from requests import HTTPError
+
+from versadm.api.api_request import ApiRequest
+from versadm.app.db.in_memory import InMemoryDb
+from versadm.app.main import create_app
+from versadm.app.util.errors import ReferentialIntegrityError, DuplicateObjectError
+from versadm.models.nist.classes.office import Office
+
+
+"""
+In this test suite we use the Office class for convenience only; the logic should be the same for any top-level
+NIST class.
+"""
+
+
+def app_client(app_state=InMemoryDb()):
+    return TestClient(create_app(app_state))
+
+
+def test_duplicate_object():
+    # SETUP
+    app_state = InMemoryDb()
+    office = Office.parse_raw('''
+    {
+      "@type": "ElectionResults.Office",
+      "@id": "ofc_Abc123",
+      "Name": {
+        "@type": "ElectionResults.InternationalizedText",
+        "Text": [
+            {
+                "@type": "ElectionResults.LanguageString",
+                "Content": "ABC123",
+                "Language": "en-US"
+            }
+        ]
+      }
+    }
+    ''')
+
+    app_state.offices.put(office)  # pre-loads the app state with the object so it's already there
+
+    # EXECUTION
+    request = ApiRequest()
+    request.data = office
+    # Attempting to post (create) an object that already exists ought to result in a duplicate object error response
+    response = app_client(app_state).post(f'/offices', json=request.dict(by_alias=True))
+    try:
+        response.raise_for_status()
+        pytest.fail('Expected duplicate object error in API response')
+    except HTTPError as ex:
+        assert ex.response.status_code == BAD_REQUEST
+        error_payload = json.loads(ex.response.text)
+        assert 'type' in error_payload
+        assert error_payload['type'] == DuplicateObjectError.error_code
+    assert response is not None
+
+
+def test_ref_integrity_error_multi_obj():
+    # SETUP
+
+    # We seed the app state with two objects that have different external IDs.
+    app_state = InMemoryDb()
+    office = Office.parse_raw('''
+    {
+      "@type": "ElectionResults.Office",
+      "@id": "",
+      "ExternalIdentifier": [
+        {
+          "@type": "ElectionResults.ExternalIdentifier",
+          "Type": "local-level",
+          "Value": "TEST_123"
+        }
+      ],
+      "Name": {
+        "@type": "ElectionResults.InternationalizedText",
+        "Text": [
+            {
+                "@type": "ElectionResults.LanguageString",
+                "Content": "ABC123",
+                "Language": "en-US"
+            }
+        ]
+      }
+    }
+    ''')
+
+    app_state.offices.put(office)  # pre-loads the app state with the object so it's already there
+    office_2 = Office.parse_raw(office.json(by_alias=True))
+    office_2.external_identifier[0].value = '456_TEST'
+    office_2.obj_id = ''
+    app_state.offices.put(office_2)
+
+    # Set up an object that has both external ids from the two already-set objects.
+    # This should cause a Ref Integrity error to be raised due to the ambiguity in object identification.
+    other_office = Office.parse_raw('''
+    {
+      "@type": "ElectionResults.Office",
+      "@id": "",
+      "ExternalIdentifier": [
+        {
+          "@type": "ElectionResults.ExternalIdentifier",
+          "Type": "local-level",
+          "Value": "TEST_123"
+        },
+        {
+          "@type": "ElectionResults.ExternalIdentifier",
+          "Type": "local-level",
+          "Value": "456_TEST"
+        }
+      ],
+      "Name": {
+        "@type": "ElectionResults.InternationalizedText",
+        "Text": [
+            {
+                "@type": "ElectionResults.LanguageString",
+                "Content": "ABC123",
+                "Language": "en-US"
+            }
+        ]
+      }
+    }
+    ''')
+
+    # EXECUTION
+    request = ApiRequest()
+    request.data = other_office
+    response = app_client(app_state).post(f'/offices', json=request.dict(by_alias=True))
+    try:
+        response.raise_for_status()
+        pytest.fail('Expected ref integrity error response in API call')
+    except HTTPError as ex:
+        assert ex.response.status_code == BAD_REQUEST
+        error_payload = json.loads(ex.response.text)
+        assert 'type' in error_payload
+        assert error_payload['type'] == ReferentialIntegrityError.error_code
+    assert response is not None
+
+
+def test_ref_integrity_error_different_obj_ids():
+    # SETUP
+
+    # We seed the app state with an object with a given internal id
+    app_state = InMemoryDb()
+    office = Office.parse_raw('''
+    {
+      "@type": "ElectionResults.Office",
+      "@id": "internal_abc",
+      "ExternalIdentifier": [
+        {
+          "@type": "ElectionResults.ExternalIdentifier",
+          "Type": "local-level",
+          "Value": "TEST_123"
+        }
+      ],
+      "Name": {
+        "@type": "ElectionResults.InternationalizedText",
+        "Text": [
+            {
+                "@type": "ElectionResults.LanguageString",
+                "Content": "ABC123",
+                "Language": "en-US"
+            }
+        ]
+      }
+    }
+    ''')
+
+    app_state.offices.put(office)  # pre-loads the app state with the object so it's already there
+
+    # Set up an object that has the same external id but a different internal obj_id
+    # This should cause a Ref Integrity error to be raised due to the use of the same external id
+    other_office = Office.parse_raw('''
+    {
+      "@type": "ElectionResults.Office",
+      "@id": "internal_xyz",
+      "ExternalIdentifier": [
+        {
+          "@type": "ElectionResults.ExternalIdentifier",
+          "Type": "local-level",
+          "Value": "TEST_123"
+        }
+      ],
+      "Name": {
+        "@type": "ElectionResults.InternationalizedText",
+        "Text": [
+            {
+                "@type": "ElectionResults.LanguageString",
+                "Content": "ABC123",
+                "Language": "en-US"
+            }
+        ]
+      }
+    }
+    ''')
+
+    # EXECUTION
+    request = ApiRequest()
+    request.data = other_office
+    response = app_client(app_state).post(f'/offices', json=request.dict(by_alias=True))
+    try:
+        response.raise_for_status()
+        pytest.fail('Expected ref integrity error response in API call')
+    except HTTPError as ex:
+        assert ex.response.status_code == BAD_REQUEST
+        error_payload = json.loads(ex.response.text)
+        assert 'type' in error_payload
+        assert error_payload['type'] == ReferentialIntegrityError.error_code
+    assert response is not None

--- a/test/versadm/models/nist/classes/nist/election_report_test.py
+++ b/test/versadm/models/nist/classes/nist/election_report_test.py
@@ -2,4 +2,4 @@ from versadm.models.nist.classes.election_report import ElectionReport
 
 
 def test_load_election_report():
-    ElectionReport.parse_file('test/resources/jetsons.json')
+    ElectionReport.parse_file('resources/jetsons.json')


### PR DESCRIPTION
- Define custom exceptions DuplicateObjectError and ReferentialIntegrityError
- Define handler for API calls that catches these and returns HTTP 400 with error object
- Add unit tests
- Fix a path reference in an existing test
- Fixes #13 